### PR TITLE
Update Slack API version

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "@slack/web-api": "6.1.0",
+    "@slack/web-api": "6.4.0",
     "dotenv": "^10.0.0",
     "ts-node": "^10.2.1"
   }

--- a/src/channels/index.ts
+++ b/src/channels/index.ts
@@ -6,8 +6,27 @@ export type Channel = {
     num_members: number
 }
 
+type ChannelFromApi = {
+    id?: string
+    name?: string
+    num_members?: number
+}
+
+// This has to be done, thanks to Slack API returning objects with all properties optional...
+const apiChannelToChannel = (original: ChannelFromApi): Channel | undefined => {
+    if (!original.id || !original.name || !original.num_members) return undefined
+
+    return {
+        id: original.id,
+        name: original.name,
+        num_members: original.num_members,
+    }
+}
+
+const properChannel = (chan: Channel | undefined): chan is Channel => chan !== undefined
+
 export type ConversationsListResult = WebAPICallResult & {
-    channels?: Channel[]
+    channels?: ChannelFromApi[]
 }
 
 export interface ConversationFetcher {
@@ -29,5 +48,5 @@ export default async function getChannels(webClient: ConversationFetcher): Promi
         throw new Error('Response from Slack is malformed and has no channel data')
     }
 
-    return response.channels
+    return response.channels.map(apiChannelToChannel).filter(properChannel)
 }

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -5,8 +5,23 @@ export type Message = {
     ts: string
 }
 
+type MessageFromAPI = {
+    type?: string
+    ts?: string
+}
+
+// This has to be done, thanks to Slack API returning objects with all properties optional...
+const apiMessageToMessage = (original: MessageFromAPI): Message | undefined => {
+    if (!original.type || !original.ts) return undefined
+
+    return {
+        type: original.type,
+        ts: original.ts,
+    }
+}
+
 export type LatestMessagesResult = WebAPICallResult & {
-    messages?: Message[]
+    messages?: MessageFromAPI[]
 }
 
 export interface MessageHistoryFetcher {
@@ -24,5 +39,5 @@ export default async function getChannelMessages(
         throw new Error(`Got a failure response from Slack, error ${response.error}`)
     }
 
-    return response.messages ? response.messages[0] : undefined
+    return response.messages && response.messages.length > 0 ? apiMessageToMessage(response.messages[0]) : undefined
 }

--- a/test/messages/messages.spec.ts
+++ b/test/messages/messages.spec.ts
@@ -18,7 +18,8 @@ describe('Getting list of messages for channel', () => {
             FakeWebClient.returningMessageList({ ok: true, messages: [fakeMessage] }),
             FAKE_CHANNEL_ID,
         )
-        expect(response).toBe(fakeMessage)
+        const expectedMessage = { type: fakeMessage.type, ts: fakeMessage.ts }
+        expect(response).toStrictEqual(expectedMessage)
     })
 
     test('returns undefined if Slack returns no messages', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -697,30 +697,31 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@slack/logger@>=1.0.0 <3.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-2.0.0.tgz#6a4e1c755849bc0f66dac08a8be54ce790ec0e6b"
-  integrity sha512-OkIJpiU2fz6HOJujhlhfIGrc8hB4ibqtf7nnbJQDerG0BqwZCfmgtK5sWzZ0TkXVRBKD5MpLrTmCYyMxoMCgPw==
+"@slack/logger@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-3.0.0.tgz#b736d4e1c112c22a10ffab0c2d364620aedcb714"
+  integrity sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==
   dependencies:
-    "@types/node" ">=8.9.0"
+    "@types/node" ">=12.0.0"
 
-"@slack/types@^1.7.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@slack/types/-/types-1.9.0.tgz#aa8f90b2f66ac54a77e42606644366f93cff4871"
-  integrity sha512-RmwgMWqOtzd2JPXdiaD/tyrDD0vtjjRDFdxN1I3tAxwBbg4aryzDUVqFc8na16A+3Xik/UN8X1hvVTw8J4EB9w==
+"@slack/types@^2.0.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.2.0.tgz#fcc3648ee20c3fb92a076b23c35bca19158d9925"
+  integrity sha512-/yHEFvgp0UY/lfFvQqbq9BocW/pM4xnGycqGAx+plRgYp96dZp1y50Whz7yzOgasEUsy5TyQfBK07cj0RwUyIg==
 
-"@slack/web-api@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.1.0.tgz#27a17f61eb72100d6722ff17f581349c41d19b5f"
-  integrity sha512-9MVHw+rDBaFvkvzm8lDNH/nlkvJCDKRIjFGMdpbyZlVLsm4rcht4qyiL71bqdyLATHXJnWknb/sl0FQGLLobIA==
+"@slack/web-api@6.4.0":
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.4.0.tgz#fe8212e4aca50c4cbafe4dac3f4b81c84c527423"
+  integrity sha512-Hi0pq60d/zCqn1UQvuSyrMcoLGNbKUBL/Tmk1b1RPTZdVYiRK8zp337glvhxTBwiaGOu+58uO5yflpK1AAuoRw==
   dependencies:
-    "@slack/logger" ">=1.0.0 <3.0.0"
-    "@slack/types" "^1.7.0"
+    "@slack/logger" "^3.0.0"
+    "@slack/types" "^2.0.0"
     "@types/is-stream" "^1.1.0"
     "@types/node" ">=12.0.0"
     axios "^0.21.1"
     eventemitter3 "^3.1.0"
     form-data "^2.5.0"
+    is-electron "^2.2.0"
     is-stream "^1.1.0"
     p-queue "^6.6.1"
     p-retry "^4.0.0"
@@ -847,7 +848,7 @@
     jest-diff "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/node@*", "@types/node@>=8.9.0":
+"@types/node@*":
   version "14.11.2"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
   integrity sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==
@@ -936,12 +937,7 @@ ansi-escapes@^4.2.1:
   dependencies:
     type-fest "^0.11.0"
 
-ansi-regex@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
-  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
-
-ansi-regex@^5.0.1:
+ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
@@ -1647,6 +1643,11 @@ is-core-module@^2.2.0:
   integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
   dependencies:
     has "^1.0.3"
+
+is-electron@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.0.tgz#8943084f09e8b731b3a7a0298a7b5d56f6b7eef0"
+  integrity sha512-SpMppC2XR3YdxSzczXReBjqs2zGscWQpBIKqwXYBFic0ERaxNVgwLCHwOLZeESfdJQjX0RDvrJ1lBXX2ij+G1Q==
 
 is-fullwidth-code-point@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Update `@slack/web-api` version. This also required quite a lot of code for mapping objects as the new version return typed responses with all properties as optional. That makes no sense IMHO but I try to handle possible empty values gracefully here (by basically ignoring the objects without required values).