### PR TITLE
Add day limit parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # A bot for reporting inactive Slack channels
 
-The bot fetches the latest message¹ for each public channel in a Slack workspace and prints a report of all channels including their name and the time of their latest message, ordered from the most inactive channel to the most active.
+The program fetches the latest message¹ for each public channel in a Slack workspace and prints a report of all channels including their name and the time it's been since their latest message (in days), ordered from the most inactive channel to the most active.
 
 It also reports all channels with less than 3 members as such channels could possibly be replaced with direct messages.
 
-To do:
-- [ ] Add a limit parameter for showing only channels with inactivity longer than _n_ days
+The program takes an optional parameter to limit the results of the first listing to only those channels that have been inactive for longer than the given amount of days.
 
-¹Note: The bot fetches only the latest top-level post to each channel, so replies made in threads are not taken into account.
+Running the program with a limit parameter:
+```
+yarn start --limit 100
+``` 
+(or `yarn start -l 100` in short).
 
-(Also, it's not really _a bot_ yet, just a program you can run locally...)
+¹Note: The program fetches only the latest top-level post to each channel, so replies made in threads are not taken into account.

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,8 +10,44 @@ if (!token) {
     throw new Error("No Slack token found, can't access the Slack API")
 }
 
-;(async () => {
-    console.log('Fetching channel info...')
-    const apiClient = new WebClient(token)
-    console.log(await reportChannelsByActivity(apiClient))
-})()
+class IllegalArgumentError extends Error {}
+
+const getLimitFromArgs = (args: string[]): number | undefined => {
+    // no additional arguments given, use no limit
+    if (args.length == 2) {
+        return undefined
+    }
+    // possibly a limit parameter given, check validity
+    if (args.length == 4) {
+        if (args[2] === '--limit' || args[2] === '-l') {
+            const dayLimit = parseInt(args[3], 10)
+            if (!Number.isNaN(dayLimit)) {
+                return dayLimit
+            }
+        }
+    }
+
+    throw new IllegalArgumentError('Illegal arguments')
+}
+
+const printUsage = () => {
+    console.log('Illegal arguments given.\n')
+    console.log('Usage:')
+    console.log('  yarn start [--limit <limit> | -l <limit>]')
+}
+
+;(async (args: string[]) => {
+    try {
+        const limit = getLimitFromArgs(args)
+        const apiClient = new WebClient(token)
+        console.log('Fetching channel info...')
+        console.log(await reportChannelsByActivity(apiClient, limit))
+    } catch (e) {
+        if (e instanceof IllegalArgumentError) {
+            printUsage()
+            process.exit(-1)
+        }
+
+        throw e
+    }
+})(process.argv)

--- a/test/report/report.spec.ts
+++ b/test/report/report.spec.ts
@@ -4,8 +4,10 @@ import { ChannelWithActivityTimestamp, listChannelsByInactiveDays, listSmallChan
 const DAY_IN_SECS = 60 * 60 * 24
 
 describe('Reporting channels by activity', () => {
-    test('lists channels by inactive days in decremental order', () => {
-        const now = new Date().getTime() / 1000
+    describe('lists channels by inactive days in decremental order', () => {
+        // adjust the "now" of the test a bit (3 s.) so that it's earlier
+        // than the "now" of the program (i.e. messages aren't in the future)
+        const now = new Date().getTime() / 1000 - 180
         const channelsWithTimestamps: ChannelWithActivityTimestamp[] = [
             {
                 name: 'channel_uno',
@@ -25,16 +27,29 @@ describe('Reporting channels by activity', () => {
             },
         ]
 
-        const expectedReport =
-            'Channels ordered by inactivity\n' +
-            '------------------------------\n' +
-            'channel_cuatro (never)\n' +
-            'channel_tres (450 days)\n' +
-            'channel_dos (25 days)\n' +
-            'channel_uno (today)\n'
-        const report = listChannelsByInactiveDays(channelsWithTimestamps)
+        test('...without a day limit', () => {
+            const expectedReport =
+                'Channels ordered by inactivity\n' +
+                '------------------------------\n' +
+                'channel_cuatro (never)\n' +
+                'channel_tres (450 days)\n' +
+                'channel_dos (25 days)\n' +
+                'channel_uno (today)\n'
+            const report = listChannelsByInactiveDays(channelsWithTimestamps)
 
-        expect(report).toEqual(expectedReport)
+            expect(report).toEqual(expectedReport)
+        })
+
+        test('...with a day limit', () => {
+            const expectedReport =
+                'Channels ordered by inactivity\n' +
+                '------------------------------\n' +
+                'channel_cuatro (never)\n' +
+                'channel_tres (450 days)\n'
+            const report = listChannelsByInactiveDays(channelsWithTimestamps, 449)
+
+            expect(report).toEqual(expectedReport)
+        })
     })
 
     test('lists small (with less than 3 members) channels by member count in incremental order', () => {


### PR DESCRIPTION
Made it possible to give a day limit for displaying inactive channels as a parameter on the command line.